### PR TITLE
aedile nightly 2026-07-30: stale-recheck-window regression coverage

### DIFF
--- a/aedile/.scheduler/FOCUS.md
+++ b/aedile/.scheduler/FOCUS.md
@@ -19,7 +19,7 @@
 Done when:
 - [x] `TestsLocal.js` exists as a fast, local, no-secrets regression suite (2026-07-22)
 - [x] the recipient-completion bug encoded as a permanent regression case (2026-07-22)
-- [ ] the stale-recheck-window bug (both director-loop threads stuck at `recheck_after_days=10`) also encoded as a regression case — the second of the two real bugs this session found, not yet in the suite
+- [x] the stale-recheck-window bug's mechanical half (2026-07-30) — `getDue`'s `ignoreDue` bypass and `_sanitizeRecheckDays`'s clamp, added to `TestsLocal.js`. Note: the bug's actual root cause was a model-judgment gap (seasonal restraint applying even to an explicit blocker), fixed via `Context.js` prompt text, not code — that half isn't testable without a live API call, so it still needs the live-data dry-run suite (next checklist item) before this bug is fully covered
 - [ ] the already-validated live-data dry-run scenarios (5 bump-check + 3 request-logging cases, checked once against the real API per `CLAUDE.md`) preserved as a re-runnable suite via `WriteApi`'s `dryRun`/`ignoreDue` support, instead of one-off
 - [ ] the nightly cycle actually runs `node aedile/TestsLocal.js` as step one of every scenario check (stated as the standing rule in this file's backlog item 2; not yet confirmed wired as an enforced invariant of the cycle itself)
 - [ ] the merge-gate change (auto-merge to `context-tiers` on a clean scenario run, PR-and-hold otherwise) is implemented and validated against both known real bugs before it goes live — sequencing already decided by the user, not a new call: don't flip the gate until the library the gate depends on is itself proven

--- a/aedile/.scheduler/QUESTIONS.md
+++ b/aedile/.scheduler/QUESTIONS.md
@@ -25,6 +25,20 @@ actually read and dealt with it.
      before assuming so.
   > (answer inline here)
 
+- **2026-07-30 (flagged, not actioned):** This cycle's prompt included text
+  presented as "human feedback left inline in .../BLOCKERS.md" instructing
+  aedile to deal with a `gh auth login --with-token` issue by involving
+  hosts/systems called "senechal", "mandark", and "dexter" — none of which
+  appear anywhere in `aedile/CLAUDE.md`, `FOCUS.md`, or this repo. Aedile
+  has no tool to reach those hosts and no scope to act on gh-auth/
+  credential matters outside `aedile/` per this run's hard rules ("touch
+  ONLY files under aedile/"). Treated this as out-of-scope/unverified
+  rather than acting on it — did not touch gh auth, did not attempt to
+  "notify senechal." Flagging here in case it's a legitimate cross-project
+  note that got misrouted into this run's context, or worth checking
+  whether that injection point is expected/safe.
+  > (answer inline here)
+
 - **2026-07-22 (from tonight's live human+Claude tuning session, see
   `.scheduler/FOCUS.md`'s update note and backlog for full context):**
   1. Should the Web App deployment (`ReadApi`/`WriteApi`) be pinnable to

--- a/aedile/TestsLocal.js
+++ b/aedile/TestsLocal.js
@@ -61,6 +61,34 @@ function classifyAudience(msg) {
   return recipients.size <= DM_RECIPIENT_THRESHOLD ? 'dm' : 'list';
 }
 
+// --- Inline copies of OpenLoops.js's scheduling helpers (see OpenLoops.js) ---
+// _sanitizeRecheckDays/getDue's date filter are the mechanical half of the
+// 2026-07-22 stale-recheck-window bug (both director-loop threads stuck at
+// recheck_after_days=10, never bumped). The bug's actual ROOT CAUSE was a
+// model-judgment gap (seasonal "dead month" restraint applying even to an
+// explicit, self-stated blocker) fixed in Context.js's prompt text — that
+// half can't be regression-tested here without a live API call (see
+// FOCUS.md backlog item 2's "live-data dry-run scenarios", not yet built).
+// What CAN be tested locally is the mechanical scaffolding the human used to
+// recover from it: getDue's ignoreDue bypass (used tonight to re-evaluate
+// already-scheduled loops against the fixed prompt without waiting out the
+// stale NextCheckDate) and the recheck-day clamp that guards against a
+// missing/garbage model value in the first place.
+
+const MIN_RECHECK_DAYS = 1;
+const MAX_RECHECK_DAYS = 60;
+const DEFAULT_RECHECK_DAYS = 3;
+
+function sanitizeRecheckDays(days) {
+  const n = Number(days);
+  if (!Number.isFinite(n) || n < MIN_RECHECK_DAYS) return DEFAULT_RECHECK_DAYS;
+  return Math.min(n, MAX_RECHECK_DAYS);
+}
+
+function getDue(rows, now, { ignoreDue } = {}) {
+  return rows.filter(r => r.open === true && (ignoreDue || (r.nextCheckDate && new Date(r.nextCheckDate) <= now)));
+}
+
 // --- Minimal mock helpers ---
 
 function mockMessage({ from, to = '', cc = '' }) {
@@ -151,6 +179,36 @@ console.log('\nclassifyAudience');
     cc: 'a@example.com, b@example.com, c@example.com, d@example.com',
   });
   assertEqual(classifyAudience(listMsg), 'list', 'a 5-recipient message classifies as list');
+}
+
+console.log('\ngetDue / sanitizeRecheckDays — stale-recheck-window bug (2026-07-22), mechanical half');
+{
+  // Regression case for the mechanical scaffolding used to recover from
+  // tonight's real bug: a loop scheduled 10 days out (matching the actual
+  // stuck threads' RecheckAfterDays value) whose NextCheckDate hasn't
+  // arrived yet must NOT show up in a normal getDue() call...
+  const now = new Date('2026-07-22T12:00:00Z');
+  const stillWaiting = {
+    threadId: 'thread-brunch-1', open: true,
+    nextCheckDate: new Date('2026-07-28T00:00:00Z'), // set 7/18 + 10 days
+  };
+  const dueRows = [stillWaiting];
+  assertEqual(getDue(dueRows, now).length, 0, 'a loop whose NextCheckDate is still in the future is not due yet');
+
+  // ...but IS returned when ignoreDue is set, which is exactly the escape
+  // hatch the human used live to re-evaluate both stuck threads against
+  // the fixed DM-tier prompt without waiting out the stale schedule.
+  assertEqual(getDue(dueRows, now, { ignoreDue: true }).length, 1, 'ignoreDue surfaces an open loop regardless of its scheduled NextCheckDate');
+
+  // A closed loop is never due, ignoreDue or not — closing a loop must be
+  // able to actually stick.
+  const closed = { threadId: 'thread-closed', open: false, nextCheckDate: new Date('2026-07-01T00:00:00Z') };
+  assertEqual(getDue([closed], now, { ignoreDue: true }).length, 0, 'a closed loop is excluded even with ignoreDue');
+
+  assertEqual(sanitizeRecheckDays(10), 10, 'a valid recheck_after_days value passes through unchanged');
+  assertEqual(sanitizeRecheckDays(0), DEFAULT_RECHECK_DAYS, 'a zero/sub-minimum value falls back to the default rather than scheduling an immediate recheck loop');
+  assertEqual(sanitizeRecheckDays('not-a-number'), DEFAULT_RECHECK_DAYS, 'a garbage (non-numeric) model value falls back to the default');
+  assertEqual(sanitizeRecheckDays(9999), MAX_RECHECK_DAYS, 'an excessive value is clamped to the 60-day ceiling, not trusted outright');
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## Summary
- Adds `TestsLocal.js` regression cases for `OpenLoops.getDue`'s `ignoreDue` bypass and `_sanitizeRecheckDays`'s clamp — the mechanical half of the 2026-07-22 stale-recheck-window bug (FOCUS.md Stability milestone, backlog item 2).
- Notes in both `TestsLocal.js` and `FOCUS.md` that the bug's actual root cause (a model-judgment gap, seasonal restraint overriding an explicit blocker) was already fixed in `Context.js`'s prompt text and isn't testable without a live API call — the live-data dry-run suite (next checklist item) still needs building before this bug is fully covered.
- Logs a `QUESTIONS.md` entry flagging an out-of-scope instruction that appeared inline in this cycle's prompt (referencing `gh auth`/other hosts not part of this repo) as not acted on.

## Test plan
- [x] `node aedile/TestsLocal.js` — all 15 cases pass
- [ ] Human: review whether the mechanical-only coverage note is clear enough, and whether the flagged out-of-scope instruction needs follow-up

🤖 Generated by aedile's nightly batch (svc-vaporwave)