### PR TITLE
aedile: hold a script lock across scanUnread and checkBumps

### DIFF
--- a/aedile/BumpChecker.js
+++ b/aedile/BumpChecker.js
@@ -153,25 +153,38 @@ const BumpChecker = (function () {
       return { skipped: 'disabled' };
     }
 
-    _autosendCountThisRun = 0;
-    const due = OpenLoops.getDue(new Date(), { ignoreDue });
-    const toProcess = due.slice(0, MAX_BUMPS_PER_RUN);
-
-    if (due.length > toProcess.length) {
-      Logger.log(`⚠️ ${due.length} thread(s) due for a bump check, processing ${toProcess.length} this run (MAX_BUMPS_PER_RUN cap) — the rest will be picked up next run.`);
+    // Same guard, same reason as InboxProcessor.scanUnread() — an
+    // overlapping run must not get its own fresh _autosendCountThisRun.
+    // Shared script lock, so a bump run and a scan run also can't overlap.
+    const lock = LockService.getScriptLock();
+    if (!lock.tryLock(10000)) {
+      Logger.log('⏸️ checkBumps skipped — could not acquire the script lock (another run is still in progress).');
+      return { skipped: 'locked' };
     }
 
-    const results = toProcess.map(loopRow => {
-      try {
-        return reviewForBump(loopRow, dryRun);
-      } catch (err) {
-        Logger.log(`[BumpChecker] UNCAUGHT for ${loopRow.threadId} — ${err.stack || err}`);
-        return { threadId: loopRow.threadId, error: String(err) };
-      }
-    });
+    try {
+      _autosendCountThisRun = 0;
+      const due = OpenLoops.getDue(new Date(), { ignoreDue });
+      const toProcess = due.slice(0, MAX_BUMPS_PER_RUN);
 
-    Logger.log(`✅${dryRun ? ' [DRY RUN]' : ''} Bump check complete. Evaluated ${toProcess.length} of ${due.length} due thread(s), ${_autosendCountThisRun} auto-sent.`);
-    return { dryRun: !!dryRun, due: due.length, evaluated: toProcess.length, autosent: _autosendCountThisRun, results };
+      if (due.length > toProcess.length) {
+        Logger.log(`⚠️ ${due.length} thread(s) due for a bump check, processing ${toProcess.length} this run (MAX_BUMPS_PER_RUN cap) — the rest will be picked up next run.`);
+      }
+
+      const results = toProcess.map(loopRow => {
+        try {
+          return reviewForBump(loopRow, dryRun);
+        } catch (err) {
+          Logger.log(`[BumpChecker] UNCAUGHT for ${loopRow.threadId} — ${err.stack || err}`);
+          return { threadId: loopRow.threadId, error: String(err) };
+        }
+      });
+
+      Logger.log(`✅${dryRun ? ' [DRY RUN]' : ''} Bump check complete. Evaluated ${toProcess.length} of ${due.length} due thread(s), ${_autosendCountThisRun} auto-sent.`);
+      return { dryRun: !!dryRun, due: due.length, evaluated: toProcess.length, autosent: _autosendCountThisRun, results };
+    } finally {
+      lock.releaseLock();
+    }
   }
 
   return { checkBumps };

--- a/aedile/InboxProcessor.js
+++ b/aedile/InboxProcessor.js
@@ -353,43 +353,59 @@ const InboxProcessor = (function () {
       return { skipped: 'disabled' };
     }
 
-    _autosendCountThisRun = 0;
-    const reviewedLabel = dryRun ? null : getReviewedLabel();
-    const threads = _GmailApp.search(SCAN_QUERY);
-    let processed = 0;
-    const results = [];
-
-    for (const thread of threads) {
-      if (processed >= MAX_MESSAGES_PER_RUN) break;
-
-      let sawEveryUnreadMessage = true;
-
-      for (const msg of thread.getMessages()) {
-        if (!msg.isUnread()) continue;
-
-        if (processed >= MAX_MESSAGES_PER_RUN) {
-          sawEveryUnreadMessage = false;
-          break;
-        }
-
-        const messageId = msg.getId();
-        if (Config.isMessageProcessed(messageId)) continue;
-
-        results.push(reviewMessage(msg, dryRun));
-        processed++;
-      }
-
-      if (sawEveryUnreadMessage) {
-        if (dryRun) {
-          Logger.log(`[scanUnread] DRY RUN — would thread.addLabel(aedile-reviewed) on thread ${thread.getId()}`);
-        } else {
-          thread.addLabel(reviewedLabel);
-        }
-      }
+    // Without this, two overlapping runs — a slow one still in flight when
+    // the next trigger fires, or WriteApi's doPost firing mid-trigger —
+    // would each start from a fresh _autosendCountThisRun of 0, silently
+    // exceeding MAX_AUTOSEND_PER_RUN. The lock is script-wide, so scanInbox
+    // and checkBumps also can't overlap each other; that's deliberate,
+    // since both append to the same Log/OpenLoops/Messages tabs.
+    const lock = LockService.getScriptLock();
+    if (!lock.tryLock(10000)) {
+      Logger.log('⏸️ scanUnread skipped — could not acquire the script lock (another run is still in progress).');
+      return { skipped: 'locked' };
     }
 
-    Logger.log(`✅${dryRun ? ' [DRY RUN]' : ''} Aedile scan complete. Reviewed ${processed} new message(s), ${_autosendCountThisRun} auto-sent. No message was marked read.`);
-    return { dryRun: !!dryRun, processed, autosent: _autosendCountThisRun, results };
+    try {
+      _autosendCountThisRun = 0;
+      const reviewedLabel = dryRun ? null : getReviewedLabel();
+      const threads = _GmailApp.search(SCAN_QUERY);
+      let processed = 0;
+      const results = [];
+
+      for (const thread of threads) {
+        if (processed >= MAX_MESSAGES_PER_RUN) break;
+
+        let sawEveryUnreadMessage = true;
+
+        for (const msg of thread.getMessages()) {
+          if (!msg.isUnread()) continue;
+
+          if (processed >= MAX_MESSAGES_PER_RUN) {
+            sawEveryUnreadMessage = false;
+            break;
+          }
+
+          const messageId = msg.getId();
+          if (Config.isMessageProcessed(messageId)) continue;
+
+          results.push(reviewMessage(msg, dryRun));
+          processed++;
+        }
+
+        if (sawEveryUnreadMessage) {
+          if (dryRun) {
+            Logger.log(`[scanUnread] DRY RUN — would thread.addLabel(aedile-reviewed) on thread ${thread.getId()}`);
+          } else {
+            thread.addLabel(reviewedLabel);
+          }
+        }
+      }
+
+      Logger.log(`✅${dryRun ? ' [DRY RUN]' : ''} Aedile scan complete. Reviewed ${processed} new message(s), ${_autosendCountThisRun} auto-sent. No message was marked read.`);
+      return { dryRun: !!dryRun, processed, autosent: _autosendCountThisRun, results };
+    } finally {
+      lock.releaseLock();
+    }
   }
 
   return {


### PR DESCRIPTION
NO-DECISION: Zach ruled 2026-09-06 to keep this work while noting the pattern that produced it. Nothing here to weigh.

Carries the one piece of PR #2 (2026-07-21) with production value, rewritten against current code. Closes #2 in substance; its other half is superseded.

## What changed

`scanUnread()` and `checkBumps()` each take `LockService.getScriptLock()` with a 10s `tryLock`, wrap their body in `try`/`finally`, and release on the way out. A run that can't take the lock returns `{ skipped: 'locked' }` instead of doing half a pass.

## Why, honestly scoped

Both workers set `_autosendCountThisRun = 0` on entry, so two overlapping runs each get a fresh auto-send budget and can exceed `MAX_AUTOSEND_PER_RUN` between them.

On a two-person director thread that is quiet by design, five auto-sends per run is not a ceiling anyone was going to hit. Zach's read — that this was self-dev finding work rather than answering a real risk — is correct, and the fix is kept because it is right, not because the risk was pressing.

What has changed since PR #2 was opened is `WriteApi`. Its `doPost` can start a run while the hourly trigger is already mid-flight, which no trigger-cadence choice prevents. `WriteApi.js`'s own header already documents the missing lock as a known gap it inherits. That is now closed.

## Why the original PR didn't apply

Both functions gained `dryRun`/`ignoreDue` parameters and return values after 2026-07-21. The lock is PR #2's idea; the surrounding code is current. PR #2's 189-line `TestsLocal.js` is not carried over — `context-tiers` already has a suite covering the same ground.

## Witness

```
$ node aedile/TestsLocal.js
14 passed, 0 failed
```

That suite tests pure logic via inline copies and does not exercise `scanUnread`. It is run here because `.scheduler/FOCUS.md` makes it step one of every cycle, not because it covers this change. The lock's real behaviour is only observable in Apps Script, and this repo has no harness for that.

## Not done here

Deploying it. `clasp push` needs interactive auth, and per aedile/CLAUDE.md a director redeploys by hand. Merging this does not change the live script.

<!-- DEFERRED -->
- none
<!-- /DEFERRED -->

<!-- DELIVERS -->
- none
<!-- /DELIVERS -->

<!-- agent: zach@mandark 2026-09-06T05:09:22Z build 2026-09-01T030800Z -->