### PR TITLE
aedile: clasp push would break the live project, and dryRun fails open

### DIFF
--- a/aedile/.claspignore
+++ b/aedile/.claspignore
@@ -1,0 +1,24 @@
+# Local test files - not for Apps Script deployment.
+#
+# TestsLocal.js is not merely unwanted up there, it is BREAKING: Apps Script
+# runs every file in one shared global scope, and TestsLocal.js declares
+# `const DM_RECIPIENT_THRESHOLD` at top level, which InboxProcessor.js already
+# declares. Two top-level `const`s of one name in one scope is a SyntaxError at
+# load, so a push carrying both stops the whole project -- triage, bumps and
+# both Web App endpoints -- not just the tests.
+TestsLocal.js
+
+# Git files
+.git/**
+.gitignore
+
+# Clasp files
+.clasp.json
+.claspignore
+
+# The nightly job's own working files. Tracked in git on purpose, never part of
+# the deployed script.
+.scheduler/**
+
+# Not JavaScript, and not wanted in the project either way.
+holon_fold.py

--- a/aedile/README.md
+++ b/aedile/README.md
@@ -50,6 +50,14 @@ generally.
 
 ## Files
 
+**Deployment**
+- `.claspignore` — what `clasp push` must NOT upload. Load-bearing, not
+  hygiene: Apps Script runs every file in one shared global scope, and
+  `TestsLocal.js` declares a top-level `const` that `InboxProcessor.js`
+  already declares. Pushing both is a `SyntaxError` at load, which stops the
+  whole project — triage, bumps and both Web App endpoints. Do not delete
+  this file to "just push everything once".
+
 **Shared**
 - `Config.js` — Config/Log tab access
 - `AnthropicClient.js` — Claude Messages API wrapper
@@ -117,15 +125,32 @@ director to archive or delete once the historical data in them isn't needed.
   and why it exists. Must include Aedile's own inbox address explicitly.
 - `BUMP_ENABLED` — gates `checkBumps()` entirely, independent of
   `AEDILE_ENABLED`/`AUTOSEND_ENABLED`. Off/unset means open loops
-  accumulate in `OpenLoops` but nothing ever acts on them. Bump drafts are
-  never eligible for auto-send, regardless of `AUTOSEND_ALLOWLIST`.
+  accumulate in `OpenLoops` but nothing ever acts on them. Bump drafts
+  **are** eligible for auto-send, under the same allowlist condition as the
+  triage tier (`InboxProcessor.isAllowlistEligible`), with their own
+  separate per-run cap — decided 2026-07-16, see `CLAUDE.md`. *(This line
+  used to say the opposite. It was wrong from the day that decision landed,
+  and it was wrong in the dangerous direction: it described a narrower blast
+  radius than the code has.)*
 - `ANTHROPIC_API_KEY` — the Claude API key `AnthropicClient.js` reads.
 - `READ_API_TOKEN` — secret gating the read-only `ReadApi.js` Web App
   endpoint. If unset, that endpoint refuses every request (fail closed).
   Independent of the kill switches above; it has no effect on the
   trigger-driven triage/bump path.
+- `WRITE_API_TOKEN` — separate secret gating `WriteApi.js`'s `doPost`, which
+  can trigger a real `scanInbox`/`checkBumps` run and therefore real
+  auto-sent mail. Deliberately not shared with `READ_API_TOKEN`, so read
+  access and trigger access are revocable independently. Fails closed.
+- `TESTING_MODE` — temporary override that suspends dead-season restraint
+  for the whitelisted director loop (`SystemPrompt.js`). Set by
+  `enableTestingMode()`, cleared by `disableTestingMode()`. Only the exact
+  string `'true'` is on. **Leaving this set is a live behaviour change**, so
+  check it before assuming aedile is observing seasonal silence.
+- `MIGRATION_DRIVE_FILE_ID` — read only by the one-time, non-idempotent
+  `migrateMessages()` archive import. Not part of any trigger path.
 
-All six live in Project Settings > Script Properties, not in code.
+All nine live in Project Settings > Script Properties, not in code.
+`checkGuardrails()` prints the first four.
 
 `installTrigger()` installs the hourly `scanInbox` trigger;
 `installBumpTrigger()` installs the daily `checkBumps` trigger. Independent

--- a/aedile/TestsLocal.js
+++ b/aedile/TestsLocal.js
@@ -184,5 +184,36 @@ console.log('\nOpenLoops._sanitizeRecheckDays — clamping guard');
   assertEqual(sanitizeRecheckDays(undefined), DEFAULT_RECHECK_DAYS, 'a missing value falls back to the default');
 }
 
+console.log('\nWriteApi.strictBool — a misread safety flag must not mean "no safety"');
+{
+  // Inline copy of WriteApi.js's strictBool (see WriteApi.js).
+  //
+  // Regression case for the fail-open dryRun parse. The old form was
+  // `String(params.dryRun) === 'true'`, so every value it did not recognise
+  // read as false and ran FOR REAL — on an endpoint that can auto-send mail
+  // via replyAll() with no human between the decision and delivery.
+  // `dryRun=1` and `dryRun=ture` are the realistic ways to hit it.
+  function strictBool(value, name) {
+    if (value === undefined || value === null || value === '') return false;
+    const s = String(value);
+    if (s === 'true') return true;
+    if (s === 'false') return false;
+    throw new Error(`${name} must be exactly "true" or "false" (got "${s}").`);
+  }
+
+  const refuses = v => {
+    try { strictBool(v, 'dryRun'); return false; } catch (err) { return true; }
+  };
+
+  assertEqual(strictBool('true', 'dryRun'), true, 'the exact string "true" is a dry run');
+  assertEqual(strictBool('false', 'dryRun'), false, 'the exact string "false" is a real run');
+  assertEqual(strictBool(undefined, 'dryRun'), false, 'absent stays a real run — no existing caller changes behaviour');
+  assertEqual(strictBool('', 'dryRun'), false, 'empty stays a real run');
+  assertEqual(refuses('1'), true, 'dryRun=1 is refused, not silently run for real');
+  assertEqual(refuses('ture'), true, 'a typo is refused, not silently run for real');
+  assertEqual(refuses('yes'), true, 'dryRun=yes is refused, not silently run for real');
+  assertEqual(refuses('TRUE'), true, 'a case variant is refused rather than guessed at');
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/aedile/WriteApi.js
+++ b/aedile/WriteApi.js
@@ -40,6 +40,15 @@
  *       improved judgment without waiting out a schedule set before the
  *       improvement existed. Not the normal daily-trigger path.
  *
+ * dryRun and ignoreDue accept ONLY the exact strings "true" and "false".
+ * Absent or empty means false, so no existing caller changes behaviour, but a
+ * value this endpoint cannot read is refused with a 400 rather than guessed
+ * at. It used to be `String(params.dryRun) === 'true'`, which read every
+ * unrecognised value as false — so `dryRun=1`, `dryRun=yes` and `dryRun=ture`
+ * each executed a REAL run that can auto-send mail. A misspelled safety flag
+ * meaning "no safety" is the wrong direction for this endpoint to fail in,
+ * and it disagreed with the token check above, which fails closed.
+ *
  * dryRun=true runs the full pipeline — Claude decision-making, eligibility/
  * cap checks — but suppresses every real side effect: no thread.replyAll(),
  * no createDraftReply(), no Gmail labels, no Sheets writes (Log/OpenLoops/
@@ -60,6 +69,28 @@ const WRITE_API = (() => {
     checkBumps: checkBumps,
   };
 
+  /**
+   * Strictly parse a boolean query parameter, defaulting to false when absent.
+   *
+   * The old form was `String(params.dryRun) === 'true'`, which treated every
+   * value it did not recognise as false. `dryRun=1`, `dryRun=yes` and
+   * `dryRun=ture` all read as "not a dry run" and executed a REAL run — one
+   * that can auto-send mail via replyAll() with no human between the decision
+   * and delivery. A misspelled safety flag quietly meaning "no safety" is the
+   * wrong direction for this endpoint to fail in, and it disagreed with the
+   * token check two lines up, which fails closed.
+   *
+   * Absent still means false, so no existing caller changes behaviour; a value
+   * this function cannot read is now refused instead of guessed at.
+   */
+  function strictBool(value, name) {
+    if (value === undefined || value === null || value === '') return false;
+    const s = String(value);
+    if (s === 'true') return true;
+    if (s === 'false') return false;
+    throw new Error(`${name} must be exactly "true" or "false" (got "${s}").`);
+  }
+
   function handle(params) {
     const configured = PropertiesService.getScriptProperties().getProperty('WRITE_API_TOKEN');
     if (!configured) return { status: 503, body: { ok: false, error: 'WRITE_API_TOKEN not set; endpoint disabled.' } };
@@ -69,8 +100,14 @@ const WRITE_API = (() => {
     const fn = ACTIONS[action];
     if (!fn) return { status: 400, body: { ok: false, error: 'Unknown action. Use one of: ' + Object.keys(ACTIONS).join(', ') } };
 
-    const dryRun = String(params.dryRun) === 'true';
-    const ignoreDue = String(params.ignoreDue) === 'true';
+    let dryRun, ignoreDue;
+    try {
+      dryRun = strictBool(params.dryRun, 'dryRun');
+      ignoreDue = strictBool(params.ignoreDue, 'ignoreDue');
+    } catch (err) {
+      return { status: 400, body: { ok: false, error: String(err.message) } };
+    }
+
     const result = action === 'checkBumps' ? fn(dryRun, ignoreDue) : fn(dryRun);
     return { status: 200, body: { ok: true, action, dryRun, ignoreDue, result } };
   }


### PR DESCRIPTION
NO-DECISION: two guards on paths that reach production, found while planning the meeting tier. Nothing to weigh — each is a repair, and neither changes behaviour for a correct caller.

Blocks the first step of media-arts-collective/wavebucks#10, which needs a `clasp push`.

## 1. `clasp push` would have stopped the live project

`aedile/` had no `.claspignore`. `scribaSenatus/` has had one all along.

`TestsLocal.js` is a plain `.js` and matches `.clasp.json`'s `scriptExtensions`, so a bare `clasp push` uploads it. Apps Script runs every file in one shared global scope, and:

```
TestsLocal.js:55       const DM_RECIPIENT_THRESHOLD = 3;
InboxProcessor.js:39   const DM_RECIPIENT_THRESHOLD = 3;
```

Two top-level `const`s of one name in one scope is a `SyntaxError` at load. Not a broken test — the whole project stops: triage, bumps, and both Web App endpoints.

Nothing has broken so far only because nobody has pushed since `TestsLocal.js` landed on 2026-07-22. The next person to deploy would have found out.

## 2. `dryRun` failed open on the one endpoint that sends mail

```js
const dryRun = String(params.dryRun) === 'true';   // every unrecognised value -> false
```

So `dryRun=1`, `dryRun=yes` and `dryRun=ture` each executed a **real** run — on the endpoint that can auto-send via `thread.replyAll()` with no human between the decision and delivery. The token check two lines above it fails closed; this did not.

Now only the exact strings `"true"` and `"false"` parse. Absent still means false, so **no existing caller changes behaviour**; anything unreadable is refused with a 400 instead of guessed at.

Inverting the default to dry-run-unless-told-otherwise was deliberately *not* done. That is a decision about what the API means, not a repair, and it belongs to whoever owns the endpoint.

## 3. The README described a safety property the code does not have

> Bump drafts are never eligible for auto-send, regardless of `AUTOSEND_ALLOWLIST`.

`BumpChecker` auto-sends via `InboxProcessor.isAllowlistEligible` with its own `MAX_BUMP_AUTOSEND_PER_RUN` cap — decided 2026-07-16 and documented in `CLAUDE.md`. The README has been wrong since that decision landed, and wrong in the dangerous direction: it described a **narrower** blast radius than the code has.

## 4. Six script properties documented, nine read

Missing: `WRITE_API_TOKEN`, `TESTING_MODE`, `MIGRATION_DRIVE_FILE_ID`. `TESTING_MODE` matters most — leaving it set suspends dead-season restraint, and its live state has been an open question in `.scheduler/QUESTIONS.md` since 2026-07-21.

## Witness

```
$ node aedile/TestsLocal.js
22 passed, 0 failed          # was 14
```

The eight new cases cover the `strictBool` parse, including `dryRun=1` and `dryRun=ture` being refused rather than silently run for real. Per the suite's own inline-copy discipline, that is a copy of `WriteApi.js`'s function — change one, change both.

The `.claspignore` half has no local witness. Its real test is a `clasp push` that leaves the editor loading without a `SyntaxError`, and that is a human step.

## Not done here

Deploying. Merging this changes no live behaviour on its own — it changes what the *next* deploy does.

<!-- DEFERRED -->
- none
<!-- /DEFERRED -->

<!-- DELIVERS -->
- none
<!-- /DELIVERS -->

<!-- agent: zach@mandark 2026-09-06T06:40:46Z build 2026-09-01T030800Z -->