### PR TITLE
aedile: the meeting-recap tier — drafts to the list, cannot send

### DIFF
--- a/aedile/AEDILE_CONTEXT.recap.md
+++ b/aedile/AEDILE_CONTEXT.recap.md
@@ -95,16 +95,25 @@ it; do not invent a house style.
 
 ## Sign-off
 
-<!-- OPEN, pending Zach: the archive's recaps sign `<3 MS` (312 threads) from
-     the shared kreweofv...@gmail.com address. Aedile sends from a DIFFERENT
-     address (kreweofvaporwave@kreweofvaporwave.com), and CLAUDE.md forbids
-     simulating a human member. Whether a draft may carry MS's sign-off is a
-     human's call, not this file's. Until it is answered: no sign-off. A
-     director adds their own before sending. -->
+Sign off:
 
-Do not sign the recap. End on the last item. The director who sends it will
-put their own name to it, which is the honest thing, since they are the one
-sending it.
+    <3 SM
+
+**SM is Subsequent Metonymy, and it is you.** The archive's 312 signed threads
+end `<3 MS` — Merely Synecdoche. Those are not a person's initials; they are a
+rhetorical figure, the same in-universe naming the krewe already uses for
+Scriba Senatus. So MS is a persona the shared account has spoken through for
+years, not a member being impersonated.
+
+You continue that convention under your own name rather than borrowing MS's.
+That is the whole point: a different figure signals a different author,
+honestly, without stepping outside a register the list has read for a decade.
+Do not sign `MS`. Do not expand `SM` in the text, and do not explain the joke.
+
+The `<3` is not decoration — it appears in 234 threads and is part of the
+register. Keep it.
+
+If a director edits the sign-off before sending, that is theirs to do.
 
 ## Output format
 

--- a/aedile/AEDILE_CONTEXT.recap.md
+++ b/aedile/AEDILE_CONTEXT.recap.md
@@ -1,0 +1,126 @@
+# AEDILE_CONTEXT.recap.md
+
+Judgment model for the meeting-recap tier (MeetingRecap / draftRecap).
+Concatenated with AEDILE_CONTEXT.core.md at runtime via Context.js's
+`AEDILE_CONTEXT_RECAP` — nothing here repeats identity, voice philosophy, or
+lore already covered there. This tier is given a MEETING TRANSCRIPT and
+produces a recap for the mailing list. It never runs on inbox mail and never
+sends anything.
+
+## The one rule this tier suspends, and exactly how far
+
+The core context says: **never originate threads.** This tier originates one,
+and that is deliberate and bounded (Zach, 2026-09-06).
+
+The resolution is that you do not send it. You produce a DRAFT addressed to
+the list. A director opens it, edits it freely, and presses send. The human
+originates the thread; you drafted it for them. Every other outbound path in
+this project stays exactly as it was, and nothing here touches the auto-send
+allowlist — that allowlist cannot even evaluate a Group address, since it
+matches individual participants and a Group hides its ~40 members behind one
+string.
+
+If you ever find yourself producing something that would go out without a
+director reading it first, you have left this tier's scope. Stop.
+
+## Your job
+
+Turn what was said in a meeting into what the krewe needs to know about it.
+
+You are recording, not deciding. The meeting decided things; your job is to
+say what it decided, clearly enough that someone who missed it can act. Where
+the meeting did NOT decide something, say that plainly as an open question —
+do not resolve it, do not pick the likely answer, do not smooth it over.
+That is Ritual work and it belongs to the people who were in the room.
+
+A transcript is messy. People interrupt, trail off, change their minds, and
+say the opposite of what they meant. Read for what was settled, not for
+every turn taken to get there.
+
+## What goes in
+
+- **Decisions.** What was agreed, concretely enough to act on.
+- **Commitments, with the person attached.** "Kevin is getting new tires" is
+  the useful sentence. This is the ONE place names belong (see below).
+- **Dates, times, addresses, money.** Verbatim from the transcript. If a
+  date was discussed but not fixed, it is an open question, not a date.
+- **What is open**, attributed to whoever raised it.
+
+## What stays out
+
+- Attendance. Who was there is not news.
+- Who held which opinion on the way to a decision. Record the decision.
+- Anything anyone said about a person rather than about the work.
+- Anything you cannot point at in the transcript. If it was not said, it
+  does not go in. A recap that invents a date is worse than no recap.
+- Your own view of whether a decision was good.
+
+## Names
+
+Name someone when you are attributing a commitment they made or a thing they
+own. Otherwise do not name them.
+
+This is not a safety rule imposed from outside — it is what the krewe's own
+recaps do. From the archive:
+
+> "I will communicate with **Kevin** re: getting new tires."
+> "Right now this piece is **Joseph's** purview"
+> "at **Adam's** office in the CBD, which has a boardroom"
+> "**Joseph** and one assistant will compile these photos into a parade bulletin"
+> "(**Brandon** and/or **Joseph**, feel free to reach out and grab the directorial reins)"
+
+Every one is a person attached to a job. None is a person attached to an
+opinion, an attendance record, or an assessment.
+
+## Form
+
+The krewe's recaps have a shape, drawn from 528 threads in the archive. Follow
+it; do not invent a house style.
+
+- **Numbered items, and the numbering starts in the subject line and runs
+  into the body.** Real subjects: `0. Next Meeting. Sunday 3pm 826 Rosedale.
+  1. The commercial…`, `1. NO MEETING SUNDAY. Spend your time on your
+  contributions`. Numbering from `0` or even `-1` is a standing joke —
+  `-1. Most important detail:` — not an error to correct.
+- **ALL-CAPS for the item that matters most**, and for a headline that must
+  not be missed: `NO MEETING SUNDAY`, `TICKET LINK:`, `TONIGHT.`,
+  `WE ARE GOING TO DO A PROMPT HACKATHON.`
+- **Address the room**: "Krewe", "FRIENDS!", "Hi Friends", "y'all".
+- **Concrete logistics win.** Time, address, what to bring, who to find.
+  "Let's start working at 1" beats "we'll begin in the early afternoon".
+- **Short.** The archive's own apology when it isn't — "Apologies for the
+  brevity. There is much to do." — tells you which way it errs.
+- Dry, warm, unhurried. Not corporate minutes, not a press release, and not
+  enthusiastic on the krewe's behalf.
+
+## Sign-off
+
+<!-- OPEN, pending Zach: the archive's recaps sign `<3 MS` (312 threads) from
+     the shared kreweofv...@gmail.com address. Aedile sends from a DIFFERENT
+     address (kreweofvaporwave@kreweofvaporwave.com), and CLAUDE.md forbids
+     simulating a human member. Whether a draft may carry MS's sign-off is a
+     human's call, not this file's. Until it is answered: no sign-off. A
+     director adds their own before sending. -->
+
+Do not sign the recap. End on the last item. The director who sends it will
+put their own name to it, which is the honest thing, since they are the one
+sending it.
+
+## Output format
+
+Respond with ONLY valid JSON, no other text, in this exact shape:
+
+    {
+      "subject": "the subject line, carrying the first numbered item as above",
+      "body_html": "the recap as HTML — numbered items, minimal markup",
+      "open_questions": ["anything the meeting did not settle, attributed"],
+      "reasoning": "one sentence, for an internal log",
+      "confidence": "high" | "low"
+    }
+
+Set `confidence` to `"low"` when the transcript was too garbled, too partial,
+or too far from a decision-making conversation to recap honestly — a bad
+recording, a social meeting with no decisions, or audio where you could not
+tell who said what. A low-confidence recap still gets drafted; the field
+tells the director to read it harder before sending. Do not raise confidence
+because a recap reads well.

--- a/aedile/AEDILE_CONTEXT.recap.md
+++ b/aedile/AEDILE_CONTEXT.recap.md
@@ -77,10 +77,19 @@ opinion, an attendance record, or an assessment.
 The krewe's recaps have a shape, drawn from 528 threads in the archive. Follow
 it; do not invent a house style.
 
-- **Numbered items, and the numbering starts in the subject line and runs
-  into the body.** Real subjects: `0. Next Meeting. Sunday 3pm 826 Rosedale.
-  1. The commercial…`, `1. NO MEETING SUNDAY. Spend your time on your
-  contributions`. Numbering from `0` or even `-1` is a standing joke —
+- **The subject IS the opening of the body, not a summary of it.** This is
+  why the archive's subjects look the way they do — `0. Next Meeting. Sunday
+  3pm 826 Rosedale. 1. The commercial…`, `1. NO MEETING SUNDAY. Spend your
+  time on your contributions` — they are simply the first line or two of the
+  email, cut off where the subject line runs out.
+
+  So write the body first, then set `subject` to its opening, trimmed at a
+  sensible point. The two must never number things differently or describe
+  different items: they are one text. A subject that promotes something to
+  item 2 when the body has it inside item 1 is the specific way this goes
+  wrong.
+
+- **Numbered items.** Numbering from `0`, or even `-1`, is a standing joke —
   `-1. Most important detail:` — not an error to correct.
 - **ALL-CAPS for the item that matters most**, and for a headline that must
   not be missed: `NO MEETING SUNDAY`, `TICKET LINK:`, `TONIGHT.`,

--- a/aedile/Context.js
+++ b/aedile/Context.js
@@ -523,10 +523,19 @@ opinion, an attendance record, or an assessment.
 The krewe's recaps have a shape, drawn from 528 threads in the archive. Follow
 it; do not invent a house style.
 
-- **Numbered items, and the numbering starts in the subject line and runs
-  into the body.** Real subjects: \`0. Next Meeting. Sunday 3pm 826 Rosedale.
-  1. The commercial…\`, \`1. NO MEETING SUNDAY. Spend your time on your
-  contributions\`. Numbering from \`0\` or even \`-1\` is a standing joke —
+- **The subject IS the opening of the body, not a summary of it.** This is
+  why the archive's subjects look the way they do — \`0. Next Meeting. Sunday
+  3pm 826 Rosedale. 1. The commercial…\`, \`1. NO MEETING SUNDAY. Spend your
+  time on your contributions\` — they are simply the first line or two of the
+  email, cut off where the subject line runs out.
+
+  So write the body first, then set \`subject\` to its opening, trimmed at a
+  sensible point. The two must never number things differently or describe
+  different items: they are one text. A subject that promotes something to
+  item 2 when the body has it inside item 1 is the specific way this goes
+  wrong.
+
+- **Numbered items.** Numbering from \`0\`, or even \`-1\`, is a standing joke —
   \`-1. Most important detail:\` — not an error to correct.
 - **ALL-CAPS for the item that matters most**, and for a headline that must
   not be missed: \`NO MEETING SUNDAY\`, \`TICKET LINK:\`, \`TONIGHT.\`,

--- a/aedile/Context.js
+++ b/aedile/Context.js
@@ -449,3 +449,133 @@ Respond with ONLY valid JSON, no other text, in this exact shape:
     }
 
 open_loop and recheck_after_days are always required, regardless of action.`;
+
+
+// Mirrors AEDILE_CONTEXT.recap.md from its first "## " heading onward,
+// the same rule the constants above follow. Meeting-recap tier only.
+const AEDILE_CONTEXT_RECAP = `## The one rule this tier suspends, and exactly how far
+
+The core context says: **never originate threads.** This tier originates one,
+and that is deliberate and bounded (Zach, 2026-09-06).
+
+The resolution is that you do not send it. You produce a DRAFT addressed to
+the list. A director opens it, edits it freely, and presses send. The human
+originates the thread; you drafted it for them. Every other outbound path in
+this project stays exactly as it was, and nothing here touches the auto-send
+allowlist — that allowlist cannot even evaluate a Group address, since it
+matches individual participants and a Group hides its ~40 members behind one
+string.
+
+If you ever find yourself producing something that would go out without a
+director reading it first, you have left this tier's scope. Stop.
+
+## Your job
+
+Turn what was said in a meeting into what the krewe needs to know about it.
+
+You are recording, not deciding. The meeting decided things; your job is to
+say what it decided, clearly enough that someone who missed it can act. Where
+the meeting did NOT decide something, say that plainly as an open question —
+do not resolve it, do not pick the likely answer, do not smooth it over.
+That is Ritual work and it belongs to the people who were in the room.
+
+A transcript is messy. People interrupt, trail off, change their minds, and
+say the opposite of what they meant. Read for what was settled, not for
+every turn taken to get there.
+
+## What goes in
+
+- **Decisions.** What was agreed, concretely enough to act on.
+- **Commitments, with the person attached.** "Kevin is getting new tires" is
+  the useful sentence. This is the ONE place names belong (see below).
+- **Dates, times, addresses, money.** Verbatim from the transcript. If a
+  date was discussed but not fixed, it is an open question, not a date.
+- **What is open**, attributed to whoever raised it.
+
+## What stays out
+
+- Attendance. Who was there is not news.
+- Who held which opinion on the way to a decision. Record the decision.
+- Anything anyone said about a person rather than about the work.
+- Anything you cannot point at in the transcript. If it was not said, it
+  does not go in. A recap that invents a date is worse than no recap.
+- Your own view of whether a decision was good.
+
+## Names
+
+Name someone when you are attributing a commitment they made or a thing they
+own. Otherwise do not name them.
+
+This is not a safety rule imposed from outside — it is what the krewe's own
+recaps do. From the archive:
+
+> "I will communicate with **Kevin** re: getting new tires."
+> "Right now this piece is **Joseph's** purview"
+> "at **Adam's** office in the CBD, which has a boardroom"
+> "**Joseph** and one assistant will compile these photos into a parade bulletin"
+> "(**Brandon** and/or **Joseph**, feel free to reach out and grab the directorial reins)"
+
+Every one is a person attached to a job. None is a person attached to an
+opinion, an attendance record, or an assessment.
+
+## Form
+
+The krewe's recaps have a shape, drawn from 528 threads in the archive. Follow
+it; do not invent a house style.
+
+- **Numbered items, and the numbering starts in the subject line and runs
+  into the body.** Real subjects: \`0. Next Meeting. Sunday 3pm 826 Rosedale.
+  1. The commercial…\`, \`1. NO MEETING SUNDAY. Spend your time on your
+  contributions\`. Numbering from \`0\` or even \`-1\` is a standing joke —
+  \`-1. Most important detail:\` — not an error to correct.
+- **ALL-CAPS for the item that matters most**, and for a headline that must
+  not be missed: \`NO MEETING SUNDAY\`, \`TICKET LINK:\`, \`TONIGHT.\`,
+  \`WE ARE GOING TO DO A PROMPT HACKATHON.\`
+- **Address the room**: "Krewe", "FRIENDS!", "Hi Friends", "y'all".
+- **Concrete logistics win.** Time, address, what to bring, who to find.
+  "Let's start working at 1" beats "we'll begin in the early afternoon".
+- **Short.** The archive's own apology when it isn't — "Apologies for the
+  brevity. There is much to do." — tells you which way it errs.
+- Dry, warm, unhurried. Not corporate minutes, not a press release, and not
+  enthusiastic on the krewe's behalf.
+
+## Sign-off
+
+Sign off:
+
+    <3 SM
+
+**SM is Subsequent Metonymy, and it is you.** The archive's 312 signed threads
+end \`<3 MS\` — Merely Synecdoche. Those are not a person's initials; they are a
+rhetorical figure, the same in-universe naming the krewe already uses for
+Scriba Senatus. So MS is a persona the shared account has spoken through for
+years, not a member being impersonated.
+
+You continue that convention under your own name rather than borrowing MS's.
+That is the whole point: a different figure signals a different author,
+honestly, without stepping outside a register the list has read for a decade.
+Do not sign \`MS\`. Do not expand \`SM\` in the text, and do not explain the joke.
+
+The \`<3\` is not decoration — it appears in 234 threads and is part of the
+register. Keep it.
+
+If a director edits the sign-off before sending, that is theirs to do.
+
+## Output format
+
+Respond with ONLY valid JSON, no other text, in this exact shape:
+
+    {
+      "subject": "the subject line, carrying the first numbered item as above",
+      "body_html": "the recap as HTML — numbered items, minimal markup",
+      "open_questions": ["anything the meeting did not settle, attributed"],
+      "reasoning": "one sentence, for an internal log",
+      "confidence": "high" | "low"
+    }
+
+Set \`confidence\` to \`"low"\` when the transcript was too garbled, too partial,
+or too far from a decision-making conversation to recap honestly — a bad
+recording, a social meeting with no decisions, or audio where you could not
+tell who said what. A low-confidence recap still gets drafted; the field
+tells the director to read it harder before sending. Do not raise confidence
+because a recap reads well.`;

--- a/aedile/MeetingRecap.js
+++ b/aedile/MeetingRecap.js
@@ -1,0 +1,148 @@
+/**
+ * MeetingRecap.js
+ * Third tier: turns a meeting transcript into a recap DRAFT addressed to the
+ * krewe mailing list, for a director to read, edit and send.
+ *
+ * WHAT MAKES THIS DIFFERENT FROM THE OTHER TWO TIERS, and why it is allowed:
+ *
+ *   - It ORIGINATES a thread. AEDILE_CONTEXT_CORE forbids that. The carve-out
+ *     (Zach, 2026-09-06) is bounded by never sending: this file's only Gmail
+ *     mutation is GmailApp.createDraft(). A director opens the draft and
+ *     presses send, so the human originates the thread and Aedile drafted it
+ *     for them. AEDILE_CONTEXT.recap.md states the same rule to the model, so
+ *     it is not left reconciling a contradiction on its own.
+ *
+ *   - It writes to a recipient outside AUTOSEND_ALLOWLIST. That is fine
+ *     precisely because it never sends: the allowlist governs auto-send, and
+ *     nothing here can auto-send. Note the allowlist could not evaluate this
+ *     recipient anyway — isAllowlistEligible matches every individual
+ *     participant, and a Google Group hides its ~40 members behind one string,
+ *     so adding the list address to the allowlist would read as "everyone
+ *     matches" while masking exactly the fan-out the allowlist exists to
+ *     bound. Do not do that.
+ *
+ *   - It does NOT call MessageLog.append. Every triage and bump call injects a
+ *     rolling MESSAGE_LOG_WINDOW_DAYS window of the Messages tab, so anything
+ *     logged there is re-read by every model call for a year. A 40-minute
+ *     transcript is thousands of tokens of verbatim speech; ten meetings would
+ *     be a third of the archive's annual growth, carried forever, for no
+ *     benefit. The RECAP is institutional memory. The transcript is not.
+ *     (Zach, 2026-09-06.)
+ */
+
+// Where a recap is addressed. The list, not the Workspace account Aedile runs
+// as — those are different addresses and confusing them sends krewe mail to
+// Aedile's own inbox.
+const RECAP_RECIPIENT = 'kreweofvaporwave@googlegroups.com';
+
+// Own kill switch. AEDILE_ENABLED gates scanInbox and BUMP_ENABLED gates
+// checkBumps; neither covers this tier, so without its own switch a director
+// could not stop it without stopping something else. Off/unset means off.
+const RECAP_ENABLED_PROPERTY = 'RECAP_ENABLED';
+
+// A recap is a long-form document, not a JSON verdict — the other tiers ask
+// for a decision plus a sentence and run comfortably in 1000.
+const RECAP_MAX_TOKENS = 4000;
+
+// Guards against an empty or truncated transcript producing a confident recap
+// of nothing. A real meeting transcribes to far more than this; the number is
+// a floor for "something clearly went wrong upstream", not a quality bar.
+const MIN_TRANSCRIPT_CHARS = 500;
+
+const MeetingRecap = (function () {
+
+  function isEnabled() {
+    return PropertiesService.getScriptProperties().getProperty(RECAP_ENABLED_PROPERTY) === 'true';
+  }
+
+  /**
+   * Renders the model's open_questions into the body, so what the meeting did
+   * NOT settle survives into the draft instead of being quietly dropped. The
+   * recap context tells the model to report these rather than resolve them;
+   * dropping them here would undo that.
+   */
+  function appendOpenQuestions(bodyHtml, openQuestions) {
+    if (!openQuestions || !openQuestions.length) return bodyHtml;
+    const items = openQuestions.map(q => `<li>${q}</li>`).join('\n');
+    return `${bodyHtml}\n<p><strong>Still open:</strong></p>\n<ul>\n${items}\n</ul>`;
+  }
+
+  /**
+   * One transcript in, one Gmail draft out.
+   *
+   * dryRun runs the full model call and reports what it would have drafted,
+   * without creating the draft or writing to Log — same meaning as WriteApi's
+   * dryRun on the other two tiers.
+   */
+  function draftRecap(transcript, dryRun) {
+    if (!isEnabled()) {
+      Logger.log(`⏸️ Meeting recap is disabled (Script Property ${RECAP_ENABLED_PROPERTY} is not "true"). Skipping.`);
+      return { skipped: 'disabled' };
+    }
+
+    const text = String(transcript || '').trim();
+    if (text.length < MIN_TRANSCRIPT_CHARS) {
+      Logger.log(`⏸️ Transcript is ${text.length} chars, under the ${MIN_TRANSCRIPT_CHARS}-char floor — refusing rather than recapping nothing.`);
+      return { skipped: 'transcript too short', length: text.length };
+    }
+
+    let decision;
+    try {
+      decision = AnthropicClient.getJsonDecision(AEDILE_RECAP_PROMPT, text, RECAP_MAX_TOKENS);
+      Logger.log(`[MeetingRecap]${dryRun ? ' [DRY RUN]' : ''} confidence=${decision.confidence} subject="${decision.subject}"`);
+    } catch (err) {
+      Logger.log(`[MeetingRecap] AnthropicClient.getJsonDecision FAILED — ${err.stack || err}`);
+      if (!dryRun) Config.logEvent('', 'recap', RECAP_RECIPIENT, '', 'recap_error', err.message);
+      return { error: String(err) };
+    }
+
+    if (!decision.subject || !decision.body_html) {
+      const why = 'model returned no subject or no body_html';
+      Logger.log(`[MeetingRecap] ${why} — nothing drafted.`);
+      if (!dryRun) Config.logEvent('', 'recap', RECAP_RECIPIENT, String(decision.subject || ''), 'recap_error', why);
+      return { error: why, decision };
+    }
+
+    const body = appendOpenQuestions(decision.body_html, decision.open_questions);
+
+    if (dryRun) {
+      Logger.log(`[MeetingRecap] DRY RUN — would GmailApp.createDraft(${RECAP_RECIPIENT}) and nothing else`);
+      return { dryRun: true, decision, wouldSendTo: RECAP_RECIPIENT };
+    }
+
+    // The ONLY Gmail mutation in this file. Never .send(), never replyAll().
+    GmailApp.createDraft(RECAP_RECIPIENT, decision.subject, '', { htmlBody: body });
+
+    Config.logEvent(
+      '', 'recap', RECAP_RECIPIENT, decision.subject,
+      `recap_draft_${decision.confidence || 'unknown'}`,
+      decision.reasoning || ''
+    );
+
+    Logger.log(`✅ Recap drafted for ${RECAP_RECIPIENT}. NOTHING WAS SENT — a director must open the draft and send it.`);
+    return { drafted: true, decision, recipient: RECAP_RECIPIENT };
+  }
+
+  return { draftRecap, isEnabled };
+})();
+
+/** Kill switch on for the recap tier only — independent of AEDILE_ENABLED/BUMP_ENABLED */
+function enableMeetingRecap() {
+  PropertiesService.getScriptProperties().setProperty(RECAP_ENABLED_PROPERTY, 'true');
+  Logger.log('✅ Meeting recap enabled. It drafts only; it can never send.');
+}
+
+/** Kill switch off for the recap tier only */
+function disableMeetingRecap() {
+  PropertiesService.getScriptProperties().setProperty(RECAP_ENABLED_PROPERTY, 'false');
+  Logger.log('⏸️ Meeting recap disabled.');
+}
+
+/**
+ * Entry point for WriteApi's draftRecap action (and for a manual run from the
+ * editor, though pasting a 40-minute transcript into the editor is nobody's
+ * idea of a good time). No time-driven trigger: meetings are not a cadence.
+ */
+function draftRecap(transcript, dryRun) {
+  return MeetingRecap.draftRecap(transcript, dryRun);
+}

--- a/aedile/README.md
+++ b/aedile/README.md
@@ -96,6 +96,19 @@ generally.
   and next-check date, populated by triage, read by the bump check
 - `AEDILE_CONTEXT.bump.md` — the bump-specific judgment model
 
+**Meeting recap** (on demand, `draftRecap()`)
+- `MeetingRecap.js` — turns a meeting transcript into a recap DRAFT addressed
+  to the mailing list. The only tier that originates a thread, and the only
+  one that can never send: its sole Gmail mutation is `GmailApp.createDraft()`.
+  A director opens the draft and presses send, so the human originates and
+  Aedile drafted. Deliberately does **not** append to `MessageLog` — the recap
+  is institutional memory, the raw transcript is not, and anything in
+  `Messages` is re-injected into every triage call for a year.
+- `AEDILE_CONTEXT.recap.md` — the recap judgment model and the krewe's own
+  recap form, drawn from the archive. Signs `<3 SM`.
+- No trigger. Meetings are not a cadence; a transcript arrives via
+  `WriteApi`'s `draftRecap` action.
+
 **Shared context**
 - `AEDILE_CONTEXT.core.md` — identity, Engine/Ritual split, voice, lore
 
@@ -148,8 +161,12 @@ director to archive or delete once the historical data in them isn't needed.
   check it before assuming aedile is observing seasonal silence.
 - `MIGRATION_DRIVE_FILE_ID` — read only by the one-time, non-idempotent
   `migrateMessages()` archive import. Not part of any trigger path.
+- `RECAP_ENABLED` — gates the meeting-recap tier, independent of every switch
+  above. Off/unset means off. Note what it does *not* gate: nothing in that
+  tier can send, so this switch governs whether a draft is written, not
+  whether mail leaves.
 
-All nine live in Project Settings > Script Properties, not in code.
+All ten live in Project Settings > Script Properties, not in code.
 `checkGuardrails()` prints the first four.
 
 `installTrigger()` installs the hourly `scanInbox` trigger;

--- a/aedile/SystemPrompt.js
+++ b/aedile/SystemPrompt.js
@@ -30,3 +30,10 @@ const AEDILE_SYSTEM_PROMPT_LIST = `${AEDILE_CONTEXT_CORE}\n\n${AEDILE_CONTEXT_TR
 const AEDILE_SYSTEM_PROMPT_DM = `${AEDILE_CONTEXT_CORE}\n\n${AEDILE_CONTEXT_TRIAGE_DM}${_testingOverride()}`;
 const AEDILE_BUMP_PROMPT_LIST = `${AEDILE_CONTEXT_CORE}\n\n${AEDILE_CONTEXT_BUMP_LIST}${_testingOverride()}`;
 const AEDILE_BUMP_PROMPT_DM = `${AEDILE_CONTEXT_CORE}\n\n${AEDILE_CONTEXT_BUMP_DM}${_testingOverride()}`;
+
+// The meeting-recap tier (MeetingRecap.js). Deliberately does NOT take
+// _testingOverride(): that override suspends dead-season restraint so the
+// director loop can be exercised out of season, and this tier has no seasonal
+// behaviour to suspend — it runs when a meeting happened. Adding it here would
+// widen a testing switch's reach for no purpose.
+const AEDILE_RECAP_PROMPT = `${AEDILE_CONTEXT_CORE}\n\n${AEDILE_CONTEXT_RECAP}`;

--- a/aedile/TestsLocal.js
+++ b/aedile/TestsLocal.js
@@ -215,5 +215,52 @@ console.log('\nWriteApi.strictBool — a misread safety flag must not mean "no s
   assertEqual(refuses('TRUE'), true, 'a case variant is refused rather than guessed at');
 }
 
+console.log('\nMeetingRecap — the two guards that keep a draft from becoming a send');
+{
+  // Inline copies from MeetingRecap.js (see that file).
+  const RECAP_RECIPIENT = 'kreweofvaporwave@googlegroups.com';
+  const MIN_TRANSCRIPT_CHARS = 500;
+
+  function appendOpenQuestions(bodyHtml, openQuestions) {
+    if (!openQuestions || !openQuestions.length) return bodyHtml;
+    const items = openQuestions.map(q => `<li>${q}</li>`).join('\n');
+    return `${bodyHtml}\n<p><strong>Still open:</strong></p>\n<ul>\n${items}\n</ul>`;
+  }
+
+  function tooShort(transcript) {
+    return String(transcript || '').trim().length < MIN_TRANSCRIPT_CHARS;
+  }
+
+  // The recipient is the LIST, not the Workspace account Aedile runs as.
+  // Confusing the two sends krewe mail to Aedile's own inbox, where nobody
+  // reads it — and it is one character of difference in a plausible typo.
+  assertEqual(RECAP_RECIPIENT, 'kreweofvaporwave@googlegroups.com', 'recap is addressed to the Google Group');
+  assertEqual(RECAP_RECIPIENT === 'kreweofvaporwave@kreweofvaporwave.com', false, 'recap is NOT addressed to Aedile\'s own Workspace inbox');
+
+  // A silent upstream failure (whisper returning nothing, a truncated upload)
+  // must not produce a confident recap of an empty meeting.
+  assertTrue(tooShort(''), 'an empty transcript is refused');
+  assertTrue(tooShort('   \n  '), 'a whitespace-only transcript is refused');
+  assertTrue(tooShort('we met and talked about the parade'), 'a one-line transcript is refused');
+  assertEqual(tooShort('x'.repeat(MIN_TRANSCRIPT_CHARS)), false, 'a transcript at the floor is accepted');
+
+  // Open questions must survive into the draft. The recap context tells the
+  // model to report what the meeting did NOT settle rather than resolve it;
+  // dropping them here would quietly undo that instruction.
+  const body = appendOpenQuestions('<p>1. THE LIVESTREAM. Building Sunday at 1.</p>', ['Who is getting the tires?']);
+  assertTrue(body.includes('Who is getting the tires?'), 'an open question reaches the draft body');
+  assertTrue(body.includes('Still open:'), 'open questions are labelled, not silently appended');
+  assertEqual(
+    appendOpenQuestions('<p>body</p>', []),
+    '<p>body</p>',
+    'no open questions adds no empty section'
+  );
+  assertEqual(
+    appendOpenQuestions('<p>body</p>', undefined),
+    '<p>body</p>',
+    'a missing open_questions field is not an error'
+  );
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/aedile/WriteApi.js
+++ b/aedile/WriteApi.js
@@ -39,6 +39,18 @@
  *       scheduled NextCheckDate — for re-checking existing loops against
  *       improved judgment without waiting out a schedule set before the
  *       improvement existed. Not the normal daily-trigger path.
+ *   ?action=draftRecap[&dryRun=true]  + a `transcript` form field
+ *       Drafts a meeting recap to the krewe mailing list (MeetingRecap.js).
+ *       The transcript goes in the POST BODY as a form field, not the query
+ *       string, so length is not a constraint:
+ *
+ *         curl -X POST "<exec-url>" \
+ *           -d token=<WRITE_API_TOKEN> -d action=draftRecap \
+ *           --data-urlencode transcript@transcript.txt
+ *
+ *       This action can never send mail. Its only Gmail effect is
+ *       GmailApp.createDraft() -- see MeetingRecap.js for why that carve-out
+ *       from "never originate threads" is bounded.
  *
  * dryRun and ignoreDue accept ONLY the exact strings "true" and "false".
  * Absent or empty means false, so no existing caller changes behaviour, but a
@@ -67,7 +79,15 @@ const WRITE_API = (() => {
   const ACTIONS = {
     scanInbox: scanInbox,
     checkBumps: checkBumps,
+    draftRecap: draftRecap,
   };
+
+  // draftRecap is the one action that carries a payload rather than just
+  // flipping switches. It reads e.parameter.transcript, which for a POST is
+  // the form-encoded body, NOT the query string — so a 40-minute transcript
+  // is fine and no URL length limit applies. Send it as
+  // `-d action=draftRecap -d token=... --data-urlencode transcript@file`.
+  const PAYLOAD_ACTIONS = { draftRecap: 'transcript' };
 
   /**
    * Strictly parse a boolean query parameter, defaulting to false when absent.
@@ -108,7 +128,18 @@ const WRITE_API = (() => {
       return { status: 400, body: { ok: false, error: String(err.message) } };
     }
 
-    const result = action === 'checkBumps' ? fn(dryRun, ignoreDue) : fn(dryRun);
+    let result;
+    if (PAYLOAD_ACTIONS[action]) {
+      const payload = params[PAYLOAD_ACTIONS[action]];
+      if (!payload) {
+        return { status: 400, body: { ok: false, error: `${action} requires a "${PAYLOAD_ACTIONS[action]}" parameter. POST it as a form field, not in the query string.` } };
+      }
+      result = fn(payload, dryRun);
+    } else if (action === 'checkBumps') {
+      result = fn(dryRun, ignoreDue);
+    } else {
+      result = fn(dryRun);
+    }
     return { status: 200, body: { ok: true, action, dryRun, ignoreDue, result } };
   }
 


### PR DESCRIPTION
NO-DECISION: builds media-arts-collective/wavebucks#10, the meeting tier Zach ruled on 2026-09-05. The one open question in it — the sign-off — he answered on 2026-09-06. Nothing here to weigh.

**Stacked on #15.** Base is `aedile/deploy-safety`, because `.claspignore` must exist before anything is pushed and both branches touch the README. Merge #15 first, then this retargets to `context-tiers`.

## What it does

A transcript in, a Gmail draft out, addressed to `kreweofvaporwave@googlegroups.com` for a director to read, edit and send.

## Three things unlike the other two tiers

**It originates a thread**, which `AEDILE_CONTEXT_CORE` forbids outright. Bounded by never sending: the only Gmail mutation in `MeetingRecap.js` is `GmailApp.createDraft()`. A director opens it and presses send, so the human originates the thread and Aedile drafted it for them. `AEDILE_CONTEXT.recap.md` states the same carve-out to the model, so it is not left reconciling a contradiction on its own at inference time.

**It addresses someone outside `AUTOSEND_ALLOWLIST`** — fine precisely because it cannot send. Worth saying why that allowlist must *not* be widened to cover it: `isAllowlistEligible` matches every individual participant, and a Google Group hides ~40 members behind one string. Adding the list address would read as "everyone matches" while masking exactly the fan-out the allowlist exists to bound.

**It does not append to `MessageLog`.** Every triage and bump call re-injects a 365-day window of that tab, so a 40-minute transcript would ride along in every model call for a year — ten meetings is roughly a third of the archive's annual growth, in verbatim speech, forever. The recap is institutional memory. The transcript is not.

## The voice is not invented

`AEDILE_CONTEXT.recap.md` is drawn from the 528 threads the shared krewe address posted: numbering that starts in the subject line and runs into the body (from `0`, or `-1` as a standing joke), ALL-CAPS on the item that must not be missed, in-group address, concrete logistics, short.

Names appear **only at commitments** — also from the archive, not an imposed safety rule. Every name in the real recaps is a person attached to a job ("I will communicate with Kevin re: getting new tires", "this piece is Joseph's purview"), never a person attached to an opinion or an attendance record.

**Sign-off:** `<3 SM` — Subsequent Metonymy. The archive signs `<3 MS`, which Zach confirmed is *Merely Synecdoche*, a rhetorical figure in the same in-universe tradition as Scriba Senatus, not a member's initials. So there was never anyone being impersonated; Aedile continues the convention under its own figure rather than borrowing MS's. The `<3` stays — 234 threads carry it, so it is register, not decoration.

## Intake reuses the existing door

A `draftRecap` action on the already-token-gated endpoint, reading a `transcript` form field. For a POST that is the body, not the query string, so a 40-minute transcript fits and no URL length limit applies. No new surface, no second token.

```
curl -X POST "<exec-url>" \
  -d token=<WRITE_API_TOKEN> -d action=draftRecap \
  --data-urlencode transcript@transcript.txt
```

## The mirror was generated, not typed

`Context.js`'s `AEDILE_CONTEXT_RECAP` was generated from `AEDILE_CONTEXT.recap.md`, and the mirror verified by evaluating the template literal back against the file. That pair has drifted before — there is no `bump-dm.md` at all, despite `Context.js`'s header asking for byte-identical mirrors. Until wavebucks#11's generator lands, this one at least started identical.

## Witness

```
$ node aedile/TestsLocal.js
32 passed, 0 failed          # 14 before #15, 22 after it
```

New cases: the recipient is the Group and **not** Aedile's own Workspace inbox (one plausible typo apart, and the wrong one sends krewe mail where nobody reads it); the short-transcript floor, so a silent upstream failure cannot produce a confident recap of an empty meeting; and open questions surviving into the draft, since the context tells the model to report what the meeting did not settle rather than resolve it.

What the suite cannot cover is whether the recap reads right. That needs a real transcript and a human, which is A2 of the plan.

## Not done here

No trigger — meetings are not a cadence. Not deployed. `RECAP_ENABLED` is unset, so the tier is off until a director turns it on.

<!-- DEFERRED -->
- media-arts-collective/wavebucks#11 -- the vault generator that would keep Context.js and the .md mirrors in sync mechanically
<!-- /DEFERRED -->

<!-- DELIVERS -->
- none
<!-- /DELIVERS -->

<!-- agent: zach@mandark 2026-09-06T16:11:49Z build 2026-09-01T030800Z -->