### PR TITLE
aedile: the repo manifest was missing the webapp block, so a push would 404 the endpoint

### DIFF
--- a/aedile/WriteApi.js
+++ b/aedile/WriteApi.js
@@ -17,11 +17,12 @@
  *     `checkBumps()` entry points a time trigger or manual run would use.
  *     It adds no bypass of any kind.
  *   - POST only (not doGet) so a bare link/prefetch can't trigger a run.
- *   - Neither worker uses LockService (a known, separately-tracked gap —
- *     see aedile/CLAUDE.md "Known bugs"), so overlapping invocations (e.g.
- *     this endpoint firing while the hourly trigger is also mid-run) carry
- *     the same already-documented risk as two overlapping time triggers.
- *     This endpoint doesn't add that risk, but doesn't fix it either.
+ *   - Both workers now take a script-wide LockService lock, so an invocation
+ *     here that overlaps a running trigger is refused with
+ *     { skipped: 'locked' } rather than starting a second run with its own
+ *     fresh auto-send counter. This endpoint was the reason that stopped
+ *     being theoretical: a time trigger overlapping itself is unlikely, but
+ *     doPost firing mid-trigger is a thing a person does on purpose.
  *
  * DEPLOY:
  *   1. clasp push

--- a/aedile/appsscript.json
+++ b/aedile/appsscript.json
@@ -3,5 +3,9 @@
   "dependencies": {
   },
   "exceptionLogging": "STACKDRIVER",
-  "runtimeVersion": "V8"
+  "runtimeVersion": "V8",
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE_ANONYMOUS"
+  }
 }


### PR DESCRIPTION
NO-DECISION: found by pulling the live project and diffing before deploying. A repair, nothing to weigh.

Found by pulling the live project and diffing before deploying, rather than
pushing and finding out.

The DEPLOYED appsscript.json carries:

    "webapp": { "executeAs": "USER_DEPLOYING", "access": "ANYONE_ANONYMOUS" }

The repo copy did not. `clasp push` overwrites appsscript.json wholesale, so
the next push would have deleted that block and taken the Execute-as/Access
config with it -- 404ing ReadApi and WriteApi until a human rebuilt the
deployment by hand in the editor.

This is the SAME failure FOCUS.md already documented for `clasp deploy`
("silently drop the Web App Execute-as/Access config and 404 the endpoint"),
reached by a different command. It was recorded as a deploy-verb problem; it
is actually a repo-does-not-carry-its-own-deployment-config problem, and push
has it too.

Also corrects a comment that the LockService merge made false: WriteApi.js
still said "Neither worker uses LockService". Both do now, and this endpoint
is why it mattered -- a time trigger overlapping itself is unlikely, but a
doPost fired mid-trigger is something a person does on purpose.

Verified: the repo manifest now parses and is key-for-key identical to the
live one.


<!-- DEFERRED -->
- none
<!-- /DEFERRED -->

<!-- DELIVERS -->
- repo:media-arts-collective/wavebucks -- the next clasp push keeps the Web App reachable instead of 404ing it
<!-- /DELIVERS -->

<!-- agent: zach@mandark 2026-09-06T16:31:54Z build 2026-09-01T030800Z -->