### PR TITLE
Deal the sign-off's closing line instead of pinning it to `<3`

### DIFF
--- a/aedile/AEDILE_CONTEXT.recap.md
+++ b/aedile/AEDILE_CONTEXT.recap.md
@@ -202,19 +202,27 @@ Sign off:
     <3 SM
 
 **SM is Subsequent Metonymy, and it is you.** The archive's 312 signed threads
-end `<3 MS`, Merely Synecdoche. Those are not a person's initials; they are a
-rhetorical figure, the same in-universe naming the krewe already uses for
-Scriba Senatus. So MS is a persona the shared account has spoken through for
-years, not a member being impersonated.
+end in `MS`, which Zach reads as Merely Synecdoche: a rhetorical figure, the
+same in-universe naming the krewe already uses for Scriba Senatus, rather than
+a person's initials. (The archive never writes the expansion out: `synecdoche`
+appears zero times in it. The reading is his, not a quotation.) So MS is a
+persona the shared account has spoken through for years, not a member being
+impersonated.
 
 You continue that convention under your own name rather than borrowing MS's.
 That is the whole point: a different figure signals a different author,
 honestly, without stepping outside a register the list has read for a decade.
 Do not sign `MS`. Do not expand `SM` in the text, and do not explain the joke.
 
-The `<3` is not decoration. It appears in 234 threads and is part of the
-register. Keep it. Write it plainly, as `<3`: the body is plain text, so there
-is no markup for it to collide with and nothing to escape.
+The `<3` is the USUAL line above the initials, not the only one. Measured over
+the 219 signed messages in this length range, the archive writes `<3` in 74%,
+a short line of its own ("Okay", "More soon!") in 10%, nothing at all in 7%,
+`xo`/`xoxo` in 4% and `Best` in 3%. If "For this email" deals you one of those,
+it replaces the `<3` and this paragraph does not override it.
+
+Whichever you get, write it plainly: the body is plain text, so there is no
+markup for it to collide with and nothing to escape. The initials are never
+optional, and they are never `MS`.
 
 If a director edits the sign-off before sending, that is theirs to do.
 

--- a/aedile/Context.js
+++ b/aedile/Context.js
@@ -652,19 +652,27 @@ Sign off:
     <3 SM
 
 **SM is Subsequent Metonymy, and it is you.** The archive's 312 signed threads
-end \`<3 MS\`, Merely Synecdoche. Those are not a person's initials; they are a
-rhetorical figure, the same in-universe naming the krewe already uses for
-Scriba Senatus. So MS is a persona the shared account has spoken through for
-years, not a member being impersonated.
+end in \`MS\`, which Zach reads as Merely Synecdoche: a rhetorical figure, the
+same in-universe naming the krewe already uses for Scriba Senatus, rather than
+a person's initials. (The archive never writes the expansion out: \`synecdoche\`
+appears zero times in it. The reading is his, not a quotation.) So MS is a
+persona the shared account has spoken through for years, not a member being
+impersonated.
 
 You continue that convention under your own name rather than borrowing MS's.
 That is the whole point: a different figure signals a different author,
 honestly, without stepping outside a register the list has read for a decade.
 Do not sign \`MS\`. Do not expand \`SM\` in the text, and do not explain the joke.
 
-The \`<3\` is not decoration. It appears in 234 threads and is part of the
-register. Keep it. Write it plainly, as \`<3\`: the body is plain text, so there
-is no markup for it to collide with and nothing to escape.
+The \`<3\` is the USUAL line above the initials, not the only one. Measured over
+the 219 signed messages in this length range, the archive writes \`<3\` in 74%,
+a short line of its own ("Okay", "More soon!") in 10%, nothing at all in 7%,
+\`xo\`/\`xoxo\` in 4% and \`Best\` in 3%. If "For this email" deals you one of those,
+it replaces the \`<3\` and this paragraph does not override it.
+
+Whichever you get, write it plainly: the body is plain text, so there is no
+markup for it to collide with and nothing to escape. The initials are never
+optional, and they are never \`MS\`.
 
 If a director edits the sign-off before sending, that is theirs to do.
 

--- a/aedile/README.md
+++ b/aedile/README.md
@@ -105,7 +105,7 @@ generally.
   is institutional memory, the raw transcript is not, and anything in
   `Messages` is re-injected into every triage call for a year.
 - `AEDILE_CONTEXT.recap.md` — the recap judgment model and the krewe's own
-  recap form, drawn from the archive. Signs `<3 SM`.
+  recap form, drawn from the archive. Signs `SM`, under a closing line dealt at the archive's rates (`<3` 74%, `Best`, `xoxo`, or none).
 - No trigger. Meetings are not a cadence; a transcript arrives via
   `WriteApi`'s `draftRecap` action.
 - `recap/redige.mjs` — **the generator, and it does not run here.** It runs on

--- a/aedile/recap/checks.mjs
+++ b/aedile/recap/checks.mjs
@@ -132,8 +132,15 @@ export function runChecks(d, notes, vault) {
 
   // 4. Form, from the archive. Sign-off, numbering, and the subject being the
   //    body's opening rather than a separate summary of it.
-  if (!/<3\s*SM\b/.test(body)) {
-    add('fail', 'sign-off', 'missing the `<3 SM` sign-off');
+  // The `<3` is DEALT now (devices.mjs `dealSignoff`), not mandatory: the
+  // archive writes it above the initials in 74% of MS-signed messages and
+  // writes `Best`, `xoxo`, a short line of its own, or nothing at all in the
+  // rest. Requiring it here pinned the generator to one of six shapes. What is
+  // not optional is the initials, and that they are SM.
+  const lastLine = body.trimEnd().split('\n').pop().trim();
+  if (!/^(?:<3[ \t]*)*SM$/.test(lastLine)) {
+    add('fail', 'sign-off',
+      `the last line must be the initials \`SM\`, alone or after \`<3\`; got ${JSON.stringify(lastLine)}`);
   }
   if (/\bMS\b/.test(body.replace(/<3\s*SM/g, ''))) {
     add('fail', 'signed-as-ms', 'signed or referred to as MS -- aedile is SM, and must not borrow the other figure');

--- a/aedile/recap/checks.test.mjs
+++ b/aedile/recap/checks.test.mjs
@@ -141,9 +141,39 @@ expectClean('a word capitalised after a colon', (() => {
 })());
 expectClean('a list ordinal followed by a capitalised word', (() => {
   const d = structuredClone(CLEAN);
-  d.body += '\n\n4. Someone should follow up.';
+  // BEFORE the sign-off. This used to append after it, which passed only while
+  // the sign-off check searched the whole body; it now reads the last line, so
+  // an item pasted below the initials is a draft that does not end in a
+  // sign-off -- which is the thing being checked, not what this case is about.
+  d.body = d.body.replace('\n\n<3 SM', '\n\n4. Someone should follow up.\n\n<3 SM');
   return d;
 })());
+
+// The archive does not always write `<3`. Measured over the 219 MS-signed
+// messages in the generator's length window, the line above the initials is
+// `<3` in 74%, a short line of its own in 10.5%, absent in 7.3%, `xo`/`xoxo`
+// in 3.7% and `Best` in 2.7%. devices.mjs deals these; the check has to accept
+// every one of them or the deal cannot reach a sent email.
+for (const [name, close] of [
+  ['a plain Best above the initials', 'Best'],
+  ['xoxo above the initials', 'xoxo'],
+  ['a short valence line above the initials', 'More soon!'],
+  ['the multi-heart variant', '<3 <3 <3'],
+]) {
+  expectClean(name, (() => {
+    const d = structuredClone(CLEAN);
+    d.body = d.body.replace('<3 SM', `${close}\nSM`);
+    return d;
+  })());
+}
+expectClean('no closing line at all -- the initials follow the last item', (() => {
+  const d = structuredClone(CLEAN);
+  d.body = d.body.replace('\n\n<3 SM', '\n\nSM');
+  return d;
+})());
+expectFinding('a draft that just stops, with no initials', d => {
+  d.body = d.body.replace('\n\n<3 SM', '');
+}, 'sign-off');
 
 
 console.log('\nthe machine-written tells');

--- a/aedile/recap/devices.mjs
+++ b/aedile/recap/devices.mjs
@@ -178,18 +178,51 @@ export const FLOURISHES = [
 /** How often the archive carries at least one, measured over the pool. */
 export const FLOURISH_RATE = 0.40;
 
-/** Rarer than the rest and dealt separately, because at 1 of 14 flourishes it
- *  came out at ~2.9% of emails against the archive's 1%. A reader clocked it as
- *  "faked me out with the special signature" and immediately asked what rate
- *  would be too obvious -- which is the right question, and the answer is that
- *  a signature variant is the most memorable thing in the email. */
-export const HEART_VARIANT_RATE = 0.01;
+/** The line above the initials. The archive does not always write `<3`.
+ *
+ *  Census of every MS-signed message in the 400-4000 character window (n=219),
+ *  by what sits directly above the initials:
+ *
+ *      `<3` alone                                   74.0%
+ *      a short valence line ("Okay", "More soon!")  10.5%
+ *      nothing -- last content line, then MS         7.3%
+ *      xo / xoxo / XOXO                              3.7%
+ *      Best                                          2.7%
+ *      `<3` with words ("<3 you all,", "<3 all of u")1.8%
+ *
+ *  These rates are NOT from the duel pool. That pool is filtered to `<3 MS`
+ *  (`duel.mjs`), so measured there the lead-in is 100% `<3` by construction and
+ *  there is nothing to learn. Re-derive from `messages.jsonl` directly.
+ *
+ *  ONE roll, not two. The multi-heart used to be dealt by its own function
+ *  alongside this, which meant a hand could say `<3 <3 <3` and `Best` at once
+ *  and hand the model two sign-offs. These are mutually exclusive shapes of a
+ *  single line, so they are one weighted draw.
+ *
+ *  The 1% ceiling on the multi-heart is kept from that earlier measurement: a
+ *  reader clocked it as "faked me out with the special signature", and a
+ *  signature variant is the most memorable thing in the email. */
+export const SIGNOFF_LEAD_INS = [
+  // The base prompt already says `<3 SM`, so the common case says nothing.
+  { key: 'heart', p: 0.740, say: null },
+  { key: 'valence', p: 0.105, say: 'Put a short line of your own above the sign-off instead of the `<3` -- "Okay", "More soon!", "Let\'s go!", "Good night friends". Then the initials.' },
+  { key: 'none', p: 0.073, say: 'No `<3` and no closing line at all. The last item ends, and the initials are on the next line.' },
+  { key: 'xo', p: 0.037, say: 'Close with `xo` or `xoxo` instead of the `<3`, then the initials.' },
+  { key: 'best', p: 0.027, say: 'Close with a plain `Best` instead of the `<3`, then the initials.' },
+  { key: 'multiHeart', p: 0.010, say: 'Sign off with more than one heart -- `<3 <3 <3` -- instead of the usual single one.' },
+  { key: 'heartWords', p: 0.008, say: 'Put words after the heart on the closing line -- `<3 you all,` or `<3 all of u` -- then the initials.' },
+];
 
-export function dealHeartVariant(seed) {
-  const rand = seed === undefined ? Math.random : rng(String(seed) + ':heart');
-  return rand() < HEART_VARIANT_RATE
-    ? 'Sign off with more than one heart -- `<3 <3 <3` -- instead of the usual single one.'
-    : null;
+/** Draw one lead-in. Returns the instruction, or null for the ordinary `<3`
+ *  the base prompt already asks for. Seeded like the rest. */
+export function dealSignoff(seed) {
+  const rand = seed === undefined ? Math.random : rng(String(seed) + ':signoff');
+  let r = rand();
+  for (const s of SIGNOFF_LEAD_INS) {
+    if (r < s.p) return s.say;
+    r -= s.p;
+  }
+  return null;  // float slack at the tail lands on the common case
 }
 
 /** Deal at most one flourish. Same seeding contract as dealDevices. */

--- a/aedile/recap/duel.mjs
+++ b/aedile/recap/duel.mjs
@@ -38,7 +38,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { readVault, buildSystemPrompt, callModelAsync, parseDecision } from './redige.mjs';
 import { normalize, isRagged } from './normalize.mjs';
-import { dealDevices, dealFlourish, dealTypo, dealHeartVariant, devicesBlock } from './devices.mjs';
+import { dealDevices, dealFlourish, dealTypo, dealSignoff, devicesBlock } from './devices.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const VAULT = process.env.KREWE_VAULT
@@ -214,11 +214,11 @@ async function buildPair(specimen, systemPrompt, seed) {
   const hand = dealDevices(`${seed}:${specimen.id}`);
   const flourish = dealFlourish(`${seed}:${specimen.id}`);
   const typo = dealTypo(`${seed}:${specimen.id}`);
-  const heart = dealHeartVariant(`${seed}:${specimen.id}`);
+  const signoff = dealSignoff(`${seed}:${specimen.id}`);
 
   const sized = [
     systemPrompt,
-    devicesBlock(hand, [flourish, heart].filter(Boolean).join('\n- '), typo),
+    devicesBlock(hand, [flourish, signoff].filter(Boolean).join('\n- '), typo),
     `## Length for this one\n\nThe finished \`body\` should be roughly ${specimen.body.length} characters. Match that; do not pad and do not truncate.`,
   ].filter(Boolean).join('\n\n');
 

--- a/aedile/recap/duel.test.mjs
+++ b/aedile/recap/duel.test.mjs
@@ -23,7 +23,8 @@ import { fileURLToPath } from 'node:url';
 
 import { normalize, isRagged, modalGap } from './normalize.mjs';
 import { leaks, carriedByNotes, units, DEVOICE_PROMPT } from './duel.mjs';
-import { dealDevices, dealFlourish, dealTypo, devicesBlock, DEVICES, FLOURISHES } from './devices.mjs';
+import { dealDevices, dealFlourish, dealTypo, dealSignoff, devicesBlock,
+         DEVICES, FLOURISHES, SIGNOFF_LEAD_INS } from './devices.mjs';
 import { parseDecision } from './redige.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -170,6 +171,36 @@ ok('the typo instruction fences off facts',
   for (let i = 0; i < 200 && !withTypo; i++) withTypo = dealTypo('t' + i);
   ok('a dealt typo carries its fence', /anybody's name/.test(withTypo || ''));
 }
+
+console.log('\nthe sign-off is dealt, not fixed');
+// The generator signed `<3 SM` at ~99% against an archive that writes `<3`
+// above the initials in 74% of MS-signed messages and something else -- or
+// nothing -- in the other 26%. Rates are measured over messages.jsonl direct,
+// NOT the duel pool: that pool is filtered to `<3 MS`, so it reads 100% `<3`
+// by construction and can teach nothing about this line.
+check('the lead-in rates are a distribution',
+  SIGNOFF_LEAD_INS.reduce((a, x) => a + x.p, 0).toFixed(6), '1.000000');
+{
+  const N = 20000, tally = {};
+  for (let i = 0; i < N; i++) {
+    const say = dealSignoff('s' + i);
+    const key = (SIGNOFF_LEAD_INS.find(x => x.say === say) || {}).key || 'heart';
+    tally[key] = (tally[key] || 0) + 1;
+  }
+  for (const { key, p } of SIGNOFF_LEAD_INS) {
+    const got = 100 * (tally[key] || 0) / N;
+    ok(`${key} lands near ${(100 * p).toFixed(1)}% (got ${got.toFixed(1)}%)`,
+      Math.abs(got - 100 * p) < 1.5);
+  }
+}
+check('the same seed deals the same sign-off', dealSignoff('abc'), dealSignoff('abc'));
+// ONE roll. The multi-heart used to be its own function rolled alongside this
+// one, so a hand could carry `<3 <3 <3` and `Best` at once and hand the model
+// two sign-offs for one email.
+ok('a hand never carries two closing lines', Array.from({ length: 2000 }, (_, i) =>
+  dealSignoff('x' + i)).every(v => v === null || SIGNOFF_LEAD_INS.some(x => x.say === v)));
+ok('the common case says nothing, leaving the prompt\'s own `<3 SM`',
+  SIGNOFF_LEAD_INS.find(x => x.key === 'heart').say === null);
 
 console.log('\nan unparseable answer costs one specimen, not the burst');
 // parseDecision used to call die(), which is process.exit(), which no pool can

--- a/aedile/recap/redige.mjs
+++ b/aedile/recap/redige.mjs
@@ -30,7 +30,7 @@ import { execFileSync, spawn } from 'node:child_process';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { runChecks, report } from './checks.mjs';
-import { dealDevices, dealFlourish, dealTypo, dealHeartVariant, devicesBlock } from './devices.mjs';
+import { dealDevices, dealFlourish, dealTypo, dealSignoff, devicesBlock } from './devices.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const AEDILE = join(HERE, '..');
@@ -373,11 +373,11 @@ function main(argv) {
   const hand = dealDevices();
   const flourish = dealFlourish();
   const typo = dealTypo();
-  const heart = dealHeartVariant();
+  const signoff = dealSignoff();
   const dealt = Object.entries(hand).filter(([, v]) => v).map(([k]) => k);
   console.error(`-- devices: ${dealt.join(', ') || 'none'}`);
 
-  const prompt = [buildSystemPrompt(vault), devicesBlock(hand, [flourish, heart].filter(Boolean).join('\n- '), typo)].filter(Boolean).join('\n\n');
+  const prompt = [buildSystemPrompt(vault), devicesBlock(hand, [flourish, signoff].filter(Boolean).join('\n- '), typo)].filter(Boolean).join('\n\n');
   let decision;
   try {
     decision = parseDecision(callModel(prompt, notes));


### PR DESCRIPTION
NO-DECISION: measured against the corpus, tests green, and it is the fix #25 specifies. Nothing here needs a ruling.

Closes #25.

The generator signed `<3 SM` at ~99%. The archive writes `<3` above the initials in **74%** of MS-signed messages and writes something else, or nothing, in the other 26%.

Census over `messages.jsonl`, MS account, 400-4000 characters (n=219), by what sits directly above the initials:

| above the initials | share |
|---|---|
| `<3` alone | 74.0% |
| a short line of its own (`Okay`, `More soon!`) | 10.5% |
| **nothing** — last item, then `MS` | 7.3% |
| `xo` / `xoxo` / `XOXO` | 3.7% |
| `Best` | 2.7% |
| `<3` with words (`<3 you all,`) | 1.8% |

## What changed

`devices.mjs` gains **`dealSignoff`**, one weighted draw over those shapes, on the same caller-rolls contract as every other device: a frequency is a fact about a corpus, and an instruction has to be about THIS email. The 74% case returns `null`, leaving the base prompt's own `<3 SM` in place.

**`dealHeartVariant` is folded in, not kept alongside.** Two independent rolls over one line could deal `<3 <3 <3` and `Best` together and hand the model two sign-offs. Its measured 1% ceiling survives as one branch of the draw.

**`checks.mjs` reads the last line** and requires the initials, `<3` optional. This is strictly stronger than the substring test it replaces, which passed on a draft with content pasted below the sign-off — the shape #23 is about.

The prompt (`AEDILE_CONTEXT.recap.md` and `Context.js`, still hand-kept in parallel per #11) says the `<3` is the usual line and defers to the deal.

## The duel filter is deliberately untouched

`duel.mjs:84` still admits only `<3 MS` specimens. Widening it *alone* would leave the real side ending variously while the generated side always ends `<3` — a sharper positional tell than the one being removed. The pool can widen from 164 to 255 in-window specimens once this has run; `normalize.mjs` already has `BARE_INITIALS` for it.

Consequently **no duel score in this PR reflects the change**, and none should be read as if it does.

## Two corrections to the prompt

It asserted all 312 signed threads end `<3 MS` — 217 do — and gave "Merely Synecdoche" as the archive's own words. The archive never writes it: `synecdoche` appears **zero** times across messages, threads, voice notes and people notes. The reading is Zach's (2026-09-06), and the prompt now says so.

## Tests

`checks.test.mjs` 26 passed, `duel.test.mjs` 78 passed. New coverage: each lead-in lands within 1.5pp of its archive rate over 20k draws, the rates sum to 1, the same seed deals the same sign-off, a hand never carries two closing lines, and `checks.mjs` accepts `Best`, `xoxo`, a valence line, `<3 <3 <3` and a bare `SM` while still failing a draft with no initials.

<!-- DEFERRED -->
- media-arts-collective/wavebucks#25 -- widening the duel pool to 255 specimens, once this has run
<!-- /DEFERRED -->

<!-- DELIVERS -->
- none
<!-- /DELIVERS -->

<!-- agent: zach@mandark 2026-09-08T01:18:05Z build 2026-09-07T031807Z -->