### PR TITLE
A heart alone is a sign-off, and #26's check rejected it

### DIFF
--- a/aedile/recap/checks.mjs
+++ b/aedile/recap/checks.mjs
@@ -137,10 +137,16 @@ export function runChecks(d, notes, vault) {
   // writes `Best`, `xoxo`, a short line of its own, or nothing at all in the
   // rest. Requiring it here pinned the generator to one of six shapes. What is
   // not optional is the initials, and that they are SM.
+  // A bare `<3` with no initials closes 0.4% of archived messages, and it is
+  // what Zach signed by hand on 2026-09-07: `MS` borrows the other figure and
+  // `SM` claims aedile's, so a heart alone keeps the register and claims
+  // neither. The generator still signs `SM` -- devices.mjs deals only the line
+  // ABOVE it -- but a draft a human closed with a heart is not malformed, and
+  // the previous version of this check rejected exactly that.
   const lastLine = body.trimEnd().split('\n').pop().trim();
-  if (!/^(?:<3[ \t]*)*SM$/.test(lastLine)) {
+  if (!/^(?:(?:<3[ \t]*)+|(?:<3[ \t]*)*SM)$/.test(lastLine)) {
     add('fail', 'sign-off',
-      `the last line must be the initials \`SM\`, alone or after \`<3\`; got ${JSON.stringify(lastLine)}`);
+      `the last line must be \`<3\`, the initials \`SM\`, or both; got ${JSON.stringify(lastLine)}`);
   }
   if (/\bMS\b/.test(body.replace(/<3\s*SM/g, ''))) {
     add('fail', 'signed-as-ms', 'signed or referred to as MS -- aedile is SM, and must not borrow the other figure');

--- a/aedile/recap/checks.test.mjs
+++ b/aedile/recap/checks.test.mjs
@@ -175,6 +175,20 @@ expectFinding('a draft that just stops, with no initials', d => {
   d.body = d.body.replace('\n\n<3 SM', '');
 }, 'sign-off');
 
+// A heart alone, no initials. 2 of 468 archived messages close this way, and
+// it is what a human signs by hand when neither figure is theirs to claim:
+// `MS` is the archive's, `SM` is aedile's. Not malformed.
+expectClean('a bare `<3` with no initials', (() => {
+  const d = structuredClone(CLEAN);
+  d.body = d.body.replace('<3 SM', '<3');
+  return d;
+})());
+expectClean('several hearts and no initials', (() => {
+  const d = structuredClone(CLEAN);
+  d.body = d.body.replace('<3 SM', '<3 <3 <3');
+  return d;
+})());
+
 
 console.log('\nthe machine-written tells');
 expectFinding('an em-dash in the body', d => {


### PR DESCRIPTION
NO-DECISION: a regression from #26, caught the same day by Zach signing a recap by hand. Tests green.

`checks.mjs` after #26 requires the initials on the last line. Zach signed a recap plain `<3` on 2026-09-07 and that draft would have been **rejected**. #26 fixed "the `<3` is mandatory" and introduced "the initials are mandatory."

Measured over the 468 MS-account messages, a bare `<3` closes **2** of them, 0.4%. Rare -- but the reason to accept it is not frequency. `MS` borrows the archive's figure and `SM` claims aedile's, so for a human who is neither, a heart alone keeps the register and claims no persona. That is the correct close, and the checker should not argue with it.

| last line | before | after |
|---|---|---|
| `<3` | **fail** | accept |
| `<3 <3 <3` | **fail** | accept |
| `SM` | accept | accept |
| `<3 SM` | accept | accept |
| `MS` | fail | fail |
| `<3 MS` | fail | fail |
| empty | fail | fail |
| a line of content | fail | fail |

**The generator is unchanged.** It still signs `SM`; `devices.mjs` deals only the line *above* the initials. This widens what the checker accepts from a hand-edited draft, nothing else.

`checks.test.mjs` 28 passed, `duel.test.mjs` 78 passed, 0 failed. Two cases added, both `expectClean`.

<!-- DEFERRED -->
- none
<!-- /DEFERRED -->

<!-- DELIVERS -->
- none
<!-- /DELIVERS -->

<!-- agent: zach@mandark 2026-09-08T03:09:30Z build 2026-09-07T031807Z -->